### PR TITLE
Fix the GitHub link

### DIFF
--- a/docs/website/blah-blah/docusaurus.config.js
+++ b/docs/website/blah-blah/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
           position: 'right',
         },
         {
-          href: 'https://getspherelabs.github.io/blahblah/',
+          href: 'https://github.com/getspherelabs/blahblah',
           label: 'GitHub',
           position: 'right',
           className: 'github',


### PR DESCRIPTION
The current GitHub link on the documentation page leads back to the documentation page.